### PR TITLE
Updated target definitions to safe clock frequency

### DIFF
--- a/examples/bare-metal/micro_speech/board_support/OSPREY-BOARD.xn
+++ b/examples/bare-metal/micro_speech/board_support/OSPREY-BOARD.xn
@@ -12,7 +12,7 @@
   <Packages>
     <Package id="0" Type="XS3-UnA-1024-QF60A">
       <Nodes>
-        <Node Id="0" InPackageId="0" Type="XS3-L16A-1024" Oscillator="24MHz" SystemFrequency="700MHz" ReferenceFrequency="100MHz">
+        <Node Id="0" InPackageId="0" Type="XS3-L16A-1024" Oscillator="24MHz" SystemFrequency="600MHz" ReferenceFrequency="100MHz">
           <Boot>
             <Source Location="bootFlash"/>
           </Boot>

--- a/examples/bare-metal/micro_speech/board_support/XCORE-AI-EXPLORER.xn
+++ b/examples/bare-metal/micro_speech/board_support/XCORE-AI-EXPLORER.xn
@@ -12,11 +12,11 @@
   <Packages>
     <Package id="0" Type="XS3-UnA-1024-FB265">
       <Nodes>
-        <Node Id="0" InPackageId="0" Type="XS3-L16A-1024" Oscillator="24MHz" SystemFrequency="700MHz" ReferenceFrequency="100MHz">
+        <Node Id="0" InPackageId="0" Type="XS3-L16A-1024" Oscillator="24MHz" SystemFrequency="600MHz" ReferenceFrequency="100MHz">
           <Boot>
             <Source Location="bootFlash"/>
           </Boot>
-          <Extmem sizeMbit="1024" Frequency="87500000Hz">
+          <Extmem sizeMbit="1024" Frequency="100MHz">
             <!-- Attributes for Padctrl and Lpddr XML elements are as per equivalently named 'Node Configuration' registers in datasheet -->
 
             <Padctrl clk="0x30" cke="0x30" cs_n="0x30" we_n="0x30" cas_n="0x30" ras_n="0x30" addr="0x30" ba="0x30" dq="0x31" dqs="0x31" dm="0x30"/>

--- a/examples/freertos/cifar10/OSPREY-BOARD.xn
+++ b/examples/freertos/cifar10/OSPREY-BOARD.xn
@@ -12,7 +12,7 @@
   <Packages>
     <Package id="0" Type="XS3-UnA-1024-QF60A">
       <Nodes>
-        <Node Id="0" InPackageId="0" Type="XS3-L16A-1024" Oscillator="24MHz" SystemFrequency="700MHz" ReferenceFrequency="100MHz">
+        <Node Id="0" InPackageId="0" Type="XS3-L16A-1024" Oscillator="24MHz" SystemFrequency="600MHz" ReferenceFrequency="100MHz">
           <Boot>
             <Source Location="bootFlash"/>
           </Boot>

--- a/examples/freertos/cifar10/XCORE-AI-EXPLORER.xn
+++ b/examples/freertos/cifar10/XCORE-AI-EXPLORER.xn
@@ -12,11 +12,11 @@
   <Packages>
     <Package id="0" Type="XS3-UnA-1024-FB265">
       <Nodes>
-        <Node Id="0" InPackageId="0" Type="XS3-L16A-1024" Oscillator="24MHz" SystemFrequency="700MHz" ReferenceFrequency="100MHz">
+        <Node Id="0" InPackageId="0" Type="XS3-L16A-1024" Oscillator="24MHz" SystemFrequency="600MHz" ReferenceFrequency="100MHz">
           <Boot>
             <Source Location="bootFlash"/>
           </Boot>
-          <Extmem sizeMbit="1024" Frequency="87500000Hz">
+          <Extmem sizeMbit="1024" Frequency="100MHz">
             <!-- Attributes for Padctrl and Lpddr XML elements are as per equivalently named 'Node Configuration' registers in datasheet -->
 
             <Padctrl clk="0x30" cke="0x30" cs_n="0x30" we_n="0x30" cas_n="0x30" ras_n="0x30" addr="0x30" ba="0x30" dq="0x31" dqs="0x31" dm="0x30"/>

--- a/examples/freertos/explorer_board/XCORE-AI-EXPLORER.xn
+++ b/examples/freertos/explorer_board/XCORE-AI-EXPLORER.xn
@@ -12,11 +12,11 @@
   <Packages>
     <Package id="0" Type="XS3-UnA-1024-FB265">
       <Nodes>
-        <Node Id="0" InPackageId="0" Type="XS3-L16A-1024" Oscillator="24MHz" SystemFrequency="700MHz" ReferenceFrequency="100MHz">
+        <Node Id="0" InPackageId="0" Type="XS3-L16A-1024" Oscillator="24MHz" SystemFrequency="600MHz" ReferenceFrequency="100MHz">
           <Boot>
             <Source Location="bootFlash"/>
           </Boot>
-          <Extmem sizeMbit="1024" Frequency="87500000Hz">
+          <Extmem sizeMbit="1024" Frequency="100MHz">
             <!-- Attributes for Padctrl and Lpddr XML elements are as per equivalently named 'Node Configuration' registers in datasheet -->
 
             <Padctrl clk="0x30" cke="0x30" cs_n="0x30" we_n="0x30" cas_n="0x30" ras_n="0x30" addr="0x30" ba="0x30" dq="0x31" dqs="0x31" dm="0x30"/>

--- a/examples/freertos/independent_tiles/XCORE-AI-EXPLORER.xn
+++ b/examples/freertos/independent_tiles/XCORE-AI-EXPLORER.xn
@@ -12,11 +12,11 @@
   <Packages>
     <Package id="0" Type="XS3-UnA-1024-FB265">
       <Nodes>
-        <Node Id="0" InPackageId="0" Type="XS3-L16A-1024" Oscillator="24MHz" SystemFrequency="700MHz" ReferenceFrequency="100MHz">
+        <Node Id="0" InPackageId="0" Type="XS3-L16A-1024" Oscillator="24MHz" SystemFrequency="600MHz" ReferenceFrequency="100MHz">
           <Boot>
             <Source Location="bootFlash"/>
           </Boot>
-          <Extmem sizeMbit="1024" Frequency="87500000Hz">
+          <Extmem sizeMbit="1024" Frequency="100MHz">
             <!-- Attributes for Padctrl and Lpddr XML elements are as per equivalently named 'Node Configuration' registers in datasheet -->
 
             <Padctrl clk="0x30" cke="0x30" cs_n="0x30" we_n="0x30" cas_n="0x30" ras_n="0x30" addr="0x30" ba="0x30" dq="0x31" dqs="0x31" dm="0x30"/>

--- a/examples/freertos/iot_aws/XCORE-AI-EXPLORER.xn
+++ b/examples/freertos/iot_aws/XCORE-AI-EXPLORER.xn
@@ -12,11 +12,11 @@
   <Packages>
     <Package id="0" Type="XS3-UnA-1024-FB265">
       <Nodes>
-        <Node Id="0" InPackageId="0" Type="XS3-L16A-1024" Oscillator="24MHz" SystemFrequency="700MHz" ReferenceFrequency="100MHz">
+        <Node Id="0" InPackageId="0" Type="XS3-L16A-1024" Oscillator="24MHz" SystemFrequency="600MHz" ReferenceFrequency="100MHz">
           <Boot>
             <Source Location="bootFlash"/>
           </Boot>
-          <Extmem sizeMbit="1024" Frequency="87500000Hz">
+          <Extmem sizeMbit="1024" Frequency="100MHz">
             <!-- Attributes for Padctrl and Lpddr XML elements are as per equivalently named 'Node Configuration' registers in datasheet -->
 
             <Padctrl clk="0x30" cke="0x30" cs_n="0x30" we_n="0x30" cas_n="0x30" ras_n="0x30" addr="0x30" ba="0x30" dq="0x31" dqs="0x31" dm="0x30"/>

--- a/examples/freertos/person_detection/XCORE-AI-EXPLORER.xn
+++ b/examples/freertos/person_detection/XCORE-AI-EXPLORER.xn
@@ -12,11 +12,11 @@
   <Packages>
     <Package id="0" Type="XS3-UnA-1024-FB265">
       <Nodes>
-        <Node Id="0" InPackageId="0" Type="XS3-L16A-1024" Oscillator="24MHz" SystemFrequency="700MHz" ReferenceFrequency="100MHz">
+        <Node Id="0" InPackageId="0" Type="XS3-L16A-1024" Oscillator="24MHz" SystemFrequency="600MHz" ReferenceFrequency="100MHz">
           <Boot>
             <Source Location="bootFlash"/>
           </Boot>
-          <Extmem sizeMbit="1024" Frequency="87500000Hz">
+          <Extmem sizeMbit="1024" Frequency="100MHz">
             <!-- Attributes for Padctrl and Lpddr XML elements are as per equivalently named 'Node Configuration' registers in datasheet -->
 
             <Padctrl clk="0x30" cke="0x30" cs_n="0x30" we_n="0x30" cas_n="0x30" ras_n="0x30" addr="0x30" ba="0x30" dq="0x31" dqs="0x31" dm="0x30"/>

--- a/examples/freertos/usb/OSPREY-BOARD.xn
+++ b/examples/freertos/usb/OSPREY-BOARD.xn
@@ -12,7 +12,7 @@
   <Packages>
     <Package id="0" Type="XS3-UnA-1024-QF60A">
       <Nodes>
-        <Node Id="0" InPackageId="0" Type="XS3-L16A-1024" Oscillator="24MHz" SystemFrequency="700MHz" ReferenceFrequency="100MHz">
+        <Node Id="0" InPackageId="0" Type="XS3-L16A-1024" Oscillator="24MHz" SystemFrequency="600MHz" ReferenceFrequency="100MHz">
           <Boot>
             <Source Location="bootFlash"/>
           </Boot>

--- a/examples/freertos/usb/XCORE-AI-EXPLORER.xn
+++ b/examples/freertos/usb/XCORE-AI-EXPLORER.xn
@@ -12,11 +12,11 @@
   <Packages>
     <Package id="0" Type="XS3-UnA-1024-FB265">
       <Nodes>
-        <Node Id="0" InPackageId="0" Type="XS3-L16A-1024" Oscillator="24MHz" SystemFrequency="700MHz" ReferenceFrequency="100MHz">
+        <Node Id="0" InPackageId="0" Type="XS3-L16A-1024" Oscillator="24MHz" SystemFrequency="600MHz" ReferenceFrequency="100MHz">
           <Boot>
             <Source Location="bootFlash"/>
           </Boot>
-          <Extmem sizeMbit="1024" Frequency="87500000Hz">
+          <Extmem sizeMbit="1024" Frequency="100MHz">
             <!-- Attributes for Padctrl and Lpddr XML elements are as per equivalently named 'Node Configuration' registers in datasheet -->
 
             <Padctrl clk="0x30" cke="0x30" cs_n="0x30" we_n="0x30" cas_n="0x30" ras_n="0x30" addr="0x30" ba="0x30" dq="0x31" dqs="0x31" dm="0x30"/>


### PR DESCRIPTION
Updated SystemFrequency to 600MHz, ExtMem Frequency to 100MHz.  These now match the defaults targets and will be safe on any xcore.ai board.