### PR TITLE
Feature/sfdp

### DIFF
--- a/examples/freertos/cifar10/src/board_init.c
+++ b/examples/freertos/cifar10/src/board_init.c
@@ -34,21 +34,14 @@ void board_tile0_init(
             1,
             qspi_io_sample_edge_rising,
             0,
+
             /** SPI read clock configuration **/
             12, // 600 MHz / (2*12) -> 25 MHz
             0,
             qspi_io_sample_edge_falling,
             0,
 
-            1, /* Enable quad page programming */
-            QSPI_IO_BYTE_TO_MOSI(0x38), /* The quad page program command */
-
-            QSPI_IO_BYTE_TO_MOSI(0x05),  /* The quad enable register read command */
-            QSPI_IO_BYTE_TO_MOSI(0x01),  /* The quad enable register write command */
-            0x40,                        /* quad_enable_bitmask */
-
-            256, /* page size is 256 bytes */
-            16384); /* the flash has 16384 pages */
+            qspi_flash_page_program_1_1_1);
 
     rtos_qspi_flash_rpc_host_init(
             qspi_flash_ctx,

--- a/examples/freertos/explorer_board/src/board_init.c
+++ b/examples/freertos/explorer_board/src/board_init.c
@@ -132,21 +132,14 @@ void board_tile0_init(
             1,
             qspi_io_sample_edge_rising,
             0,
+
             /** SPI read clock configuration **/
             12, // 600 MHz / (2*12) -> 25 MHz
             0,
             qspi_io_sample_edge_falling,
             0,
 
-            1, /* Enable quad page programming */
-            QSPI_IO_BYTE_TO_MOSI(0x38), /* The quad page program command */
-
-            QSPI_IO_BYTE_TO_MOSI(0x05),  /* The quad enable register read command */
-            QSPI_IO_BYTE_TO_MOSI(0x01),  /* The quad enable register write command */
-            0x40,                        /* quad_enable_bitmask */
-
-            256, /* page size is 256 bytes */
-            16384); /* the flash has 16384 pages */
+            qspi_flash_page_program_1_4_4);
 
     rtos_i2c_master_rpc_host_init(
             i2c_master_ctx,

--- a/examples/freertos/independent_tiles/src/board_init.c
+++ b/examples/freertos/independent_tiles/src/board_init.c
@@ -154,14 +154,14 @@ void board_tile0_init(
             qspi_io_sample_edge_falling,
             0,
 
-            qspi_flash_page_program_1_4_4,
+            qspi_flash_page_program_1_4_4);
 
-            QSPI_IO_BYTE_TO_MOSI(0x05),  /* The quad enable register read command */
-            QSPI_IO_BYTE_TO_MOSI(0x01),  /* The quad enable register write command */
-            0x40,                        /* quad_enable_bitmask */
-
-            256, /* page size is 256 bytes */
-            16384); /* the flash has 16384 pages */
+//            QSPI_IO_BYTE_TO_MOSI(0x05),  /* The quad enable register read command */
+//            QSPI_IO_BYTE_TO_MOSI(0x01),  /* The quad enable register write command */
+//            0x40,                        /* quad_enable_bitmask */
+//
+//            256, /* page size is 256 bytes */
+//            16384); /* the flash has 16384 pages */
 
     rtos_gpio_init(
             gpio_ctx);

--- a/examples/freertos/independent_tiles/src/board_init.c
+++ b/examples/freertos/independent_tiles/src/board_init.c
@@ -148,6 +148,7 @@ void board_tile0_init(
             1,
             qspi_io_sample_edge_rising,
             0,
+
             /** SPI read clock configuration **/
             12, // 600 MHz / (2*12) -> 25 MHz
             0,
@@ -155,13 +156,6 @@ void board_tile0_init(
             0,
 
             qspi_flash_page_program_1_4_4);
-
-//            QSPI_IO_BYTE_TO_MOSI(0x05),  /* The quad enable register read command */
-//            QSPI_IO_BYTE_TO_MOSI(0x01),  /* The quad enable register write command */
-//            0x40,                        /* quad_enable_bitmask */
-//
-//            256, /* page size is 256 bytes */
-//            16384); /* the flash has 16384 pages */
 
     rtos_gpio_init(
             gpio_ctx);

--- a/examples/freertos/independent_tiles/src/board_init.c
+++ b/examples/freertos/independent_tiles/src/board_init.c
@@ -154,8 +154,7 @@ void board_tile0_init(
             qspi_io_sample_edge_falling,
             0,
 
-            1, /* Enable quad page programming */
-            QSPI_IO_BYTE_TO_MOSI(0x38), /* The quad page program command */
+            qspi_flash_page_program_1_4_4,
 
             QSPI_IO_BYTE_TO_MOSI(0x05),  /* The quad enable register read command */
             QSPI_IO_BYTE_TO_MOSI(0x01),  /* The quad enable register write command */

--- a/examples/freertos/independent_tiles/src/main.c
+++ b/examples/freertos/independent_tiles/src/main.c
@@ -241,6 +241,8 @@ void vApplicationDaemonTaskStartup(void *arg)
         uint8_t data[len];
         int erase = 0;
 
+        rtos_printf("The QSPI flash size is %u\n", rtos_qspi_flash_size_get(qspi_flash_ctx));
+
         rtos_qspi_flash_read(qspi_flash_ctx, data, 0, len);
         if (data[0] != 0xFF) {
             rtos_printf("First read: %s", data);

--- a/examples/freertos/iot_aws/src/board_init.c
+++ b/examples/freertos/iot_aws/src/board_init.c
@@ -57,21 +57,14 @@ void board_tile0_init(
             1,
             qspi_io_sample_edge_rising,
             0,
+
             /** SPI read clock configuration **/
             12, // 600 MHz / (2*12) -> 25 MHz
             0,
             qspi_io_sample_edge_falling,
             0,
 
-            1, /* Enable quad page programming */
-            QSPI_IO_BYTE_TO_MOSI(0x38), /* The quad page program command */
-
-            QSPI_IO_BYTE_TO_MOSI(0x05),  /* The quad enable register read command */
-            QSPI_IO_BYTE_TO_MOSI(0x01),  /* The quad enable register write command */
-            0x40,                        /* quad_enable_bitmask */
-
-            256, /* page size is 256 bytes */
-            16384); /* the flash has 16384 pages */
+            qspi_flash_page_program_1_1_1);
 
 }
 

--- a/examples/freertos/usb/src/board_init.c
+++ b/examples/freertos/usb/src/board_init.c
@@ -120,8 +120,7 @@ void board_tile0_init(
             qspi_io_sample_edge_falling,
             0,
 
-            2, /* Enable quad page programming */
-            QSPI_IO_BYTE_TO_MOSI(0x32), /* The quad page program command */
+            qspi_flash_page_program_1_1_4,
 
             QSPI_IO_BYTE_TO_MOSI(0x35), /* The quad enable register read command */
             QSPI_IO_BYTE_TO_MOSI(0x31), /* The quad enable register write command */
@@ -150,8 +149,7 @@ void board_tile0_init(
             qspi_io_sample_edge_falling,
             0,
 
-            1, /* Enable quad page programming */
-            QSPI_IO_BYTE_TO_MOSI(0x38), /* The quad page program command */
+            qspi_flash_page_program_1_4_4,
 
             QSPI_IO_BYTE_TO_MOSI(0x05),  /* The quad enable register read command */
             QSPI_IO_BYTE_TO_MOSI(0x01),  /* The quad enable register write command */

--- a/examples/freertos/usb/src/board_init.c
+++ b/examples/freertos/usb/src/board_init.c
@@ -120,14 +120,14 @@ void board_tile0_init(
             qspi_io_sample_edge_falling,
             0,
 
-            qspi_flash_page_program_1_1_4,
+            qspi_flash_page_program_1_1_4);
 
-            QSPI_IO_BYTE_TO_MOSI(0x35), /* The quad enable register read command */
-            QSPI_IO_BYTE_TO_MOSI(0x31), /* The quad enable register write command */
-            0x02, /* quad_enable_bitmask */
-
-            256, /* page size is 256 bytes */
-            32768); /* the flash has 32768 pages */
+//            QSPI_IO_BYTE_TO_MOSI(0x35), /* The quad enable register read command */
+//            QSPI_IO_BYTE_TO_MOSI(0x31), /* The quad enable register write command */
+//            0x02, /* quad_enable_bitmask */
+//
+//            256, /* page size is 256 bytes */
+//            32768); /* the flash has 32768 pages */
 #endif
 #if XCOREAI_EXPLORER
             XS1_CLKBLK_1,
@@ -149,14 +149,14 @@ void board_tile0_init(
             qspi_io_sample_edge_falling,
             0,
 
-            qspi_flash_page_program_1_4_4,
+            qspi_flash_page_program_1_4_4);
 
-            QSPI_IO_BYTE_TO_MOSI(0x05),  /* The quad enable register read command */
-            QSPI_IO_BYTE_TO_MOSI(0x01),  /* The quad enable register write command */
-            0x40,                        /* quad_enable_bitmask */
-
-            256, /* page size is 256 bytes */
-            16384); /* the flash has 32768 pages */
+//            QSPI_IO_BYTE_TO_MOSI(0x05),  /* The quad enable register read command */
+//            QSPI_IO_BYTE_TO_MOSI(0x01),  /* The quad enable register write command */
+//            0x40,                        /* quad_enable_bitmask */
+//
+//            256, /* page size is 256 bytes */
+//            16384); /* the flash has 32768 pages */
 #endif
 #endif
 

--- a/examples/freertos/usb/src/board_init.c
+++ b/examples/freertos/usb/src/board_init.c
@@ -99,65 +99,28 @@ void board_tile0_init(
 #if OSPREY_BOARD || XCOREAI_EXPLORER
     rtos_qspi_flash_init(
             qspi_flash_ctx,
-
-#if OSPREY_BOARD
             XS1_CLKBLK_1,
             PORT_SQI_CS,
             PORT_SQI_SCLK,
             PORT_SQI_SIO,
 
-            /** Derive QSPI clock from the 700 MHz xcore clock **/
+            /** Derive QSPI clock from the xcore clock **/
             qspi_io_source_clock_xcore,
 
             /** Full speed clock configuration **/
-            5, // 700 MHz / (2*5) -> 70 MHz,
+            5, // eg. 700 MHz / (2*5) -> 70 MHz,
             1,
             qspi_io_sample_edge_rising,
             0,
+
             /** SPI read clock configuration **/
-            12, // 700 MHz / (2*12) -> ~29 MHz
+            12, // eg. 700 MHz / (2*12) -> ~29 MHz
             0,
             qspi_io_sample_edge_falling,
             0,
 
-            qspi_flash_page_program_1_1_4);
-
-//            QSPI_IO_BYTE_TO_MOSI(0x35), /* The quad enable register read command */
-//            QSPI_IO_BYTE_TO_MOSI(0x31), /* The quad enable register write command */
-//            0x02, /* quad_enable_bitmask */
-//
-//            256, /* page size is 256 bytes */
-//            32768); /* the flash has 32768 pages */
-#endif
-#if XCOREAI_EXPLORER
-            XS1_CLKBLK_1,
-            PORT_SQI_CS,
-            PORT_SQI_SCLK,
-            PORT_SQI_SIO,
-
-            /** Derive QSPI clock from the 700 MHz xcore clock **/
-            qspi_io_source_clock_xcore,
-
-            /** Full speed clock configuration **/
-            5, // 700 MHz / (2*5) -> 70 MHz,
-            1,
-            qspi_io_sample_edge_rising,
-            0,
-            /** SPI read clock configuration **/
-            12, // 700 MHz / (2*12) -> ~29 MHz
-            0,
-            qspi_io_sample_edge_falling,
-            0,
-
-            qspi_flash_page_program_1_4_4);
-
-//            QSPI_IO_BYTE_TO_MOSI(0x05),  /* The quad enable register read command */
-//            QSPI_IO_BYTE_TO_MOSI(0x01),  /* The quad enable register write command */
-//            0x40,                        /* quad_enable_bitmask */
-//
-//            256, /* page size is 256 bytes */
-//            16384); /* the flash has 32768 pages */
-#endif
+            /* This standard PP command is universal */
+            qspi_flash_page_program_1_1_1);
 #endif
 
 #if OSPREY_BOARD || XCOREAI_EXPLORER

--- a/modules/hil/lib_qspi_io/lib_qspi_io/api/qspi_flash.h
+++ b/modules/hil/lib_qspi_io/lib_qspi_io/api/qspi_flash.h
@@ -94,7 +94,7 @@ typedef struct {
 
     uint32_t busy_poll_cmd;
     uint8_t busy_poll_bit;
-    uint8_t busy_poll_busy_value;
+    uint8_t busy_poll_ready_value;
 
     /* 1 or 2. 0 means quad mode is automatically detected and cannot be explicitly entered */
     uint8_t qe_reg;

--- a/modules/hil/lib_qspi_io/lib_qspi_io/api/qspi_flash.h
+++ b/modules/hil/lib_qspi_io/lib_qspi_io/api/qspi_flash.h
@@ -124,13 +124,13 @@ typedef enum {
  * The bit mask for the status register's write
  * in progress bit.
  */
-#define QSPI_FLASH_STATUS_REG_WIP_BM 0x00000001
+#define QSPI_FLASH_STATUS_REG_WIP_BM 0x01
 
 /**
  * The bit mask for the status register's write
  * enable latch bit.
  */
-#define QSPI_FLASH_STATUS_REG_WEL_BM 0x00000002
+#define QSPI_FLASH_STATUS_REG_WEL_BM 0x02
 
 /*
  * Returns the erase size in bytes associated with the given erase type.
@@ -178,11 +178,20 @@ inline uint32_t qspi_flash_erase_type_size_log2(qspi_flash_ctx_t *ctx, qspi_flas
 /**
  * Sets or clears the quad enable bit in the flash.
  *
+ * \note The quad enable bit is fixed to '1' in some QSPI flash
+ * chips, and cannot be cleared.
+ *
  * \param ctx  The QSPI flash context associated with the QSPI flash.
  * \param set  When true, the quad enable bit is set. When false,
- *             the quad enable bit is cleared.
+ *             the quad enable bit is cleared if possible.
+ *
+ * \retval true if the QE bit was already at the requested value,
+ *         or if the write was successful.
+ * \retval false if the write did not complete successfully. This
+ *         can happen when trying to clear the QE bit on parts where
+ *         it is fixed to '1'.
  */
-void qspi_flash_quad_enable_write(qspi_flash_ctx_t *ctx, bool set);
+bool qspi_flash_quad_enable_write(qspi_flash_ctx_t *ctx, bool set);
 
 /**
  * Sets the write enable latch in the QSPI flash. This must be called

--- a/modules/hil/lib_qspi_io/lib_qspi_io/api/qspi_io.h
+++ b/modules/hil/lib_qspi_io/lib_qspi_io/api/qspi_io.h
@@ -367,7 +367,6 @@ inline void qspi_io_start_transaction(qspi_io_ctx_t *ctx,
 		ctx->sio_pad_delay = QSPI_IO_SETC_PAD_DELAY(ctx->full_speed_sio_pad_delay);
 		ctx->sio_drive     = XS1_SETC_DRIVE_DRIVE; /* disable pullups during the read */
 	}
-	//clock_start(ctx->clock_block);
 
 	first_word = byterev(first_word);
 	first_word = qspi_io_nibble_swap(first_word);

--- a/modules/hil/lib_qspi_io/lib_qspi_io/api/sfdp.h
+++ b/modules/hil/lib_qspi_io/lib_qspi_io/api/sfdp.h
@@ -1,0 +1,155 @@
+// Copyright 2021 XMOS LIMITED.
+// This Software is subject to the terms of the XMOS Public Licence: Version 1.
+
+#ifndef SFDP_H_
+#define SFDP_H_
+
+#include <stdlib.h>
+#include <stdint.h>
+#include <stdbool.h>
+
+#define SFDP_READ_INSTRUCTION 0x5A
+
+typedef struct {
+    uint32_t signature;
+    uint8_t minor_revision;
+    uint8_t major_revision;
+    uint8_t nph;
+    uint8_t : 8;
+} sfdp_header_t;
+
+typedef struct {
+    uint8_t id_lsb;
+    uint8_t minor_revision;
+    uint8_t major_revision;
+    uint8_t length;
+    uint32_t table_address : 24;
+    uint8_t id_msb;
+} sfdp_parameter_header_t;
+
+enum {
+    sfdp_3_byte_address      = 0,
+    sfdp_3_or_4_byte_address = 1,
+    sfdp_4_byte_address      = 2,
+};
+
+#define SFDP_BUSY_POLL_LEGACY_BM 0x01
+#define SFDP_BUSY_POLL_ALT1_BM   0x02
+
+typedef struct {
+    /* 1st DWORD */
+    uint32_t : 2; /* legacy */
+    uint32_t : 1; /* legacy */
+    uint32_t : 1; /* legacy */
+    uint32_t : 1; /* legacy */
+    uint32_t : 3; /* unused */
+    uint32_t : 8; /* erase table used instead */
+    uint32_t : 1; /* supports 1-1-2 fast read */
+    uint32_t address_bytes : 2;
+    uint32_t : 1; /* DTR clocking */
+    uint32_t : 1; /* supports 1-2-2 fast read */
+    uint32_t supports_144_fast_read: 1;
+    uint32_t supports_114_fast_read: 1;
+    uint32_t : 9; /* unused */
+
+    /* 2nd DWORD */
+    uint32_t memory_density : 30;
+    uint32_t memory_density_is_exponent : 1;
+
+    /* 3rd DWORD */
+    uint8_t quad_144_read_dummy_clocks : 5;
+    uint8_t quad_144_read_mode_clocks : 3;
+    uint8_t quad_144_read_cmd;
+    uint8_t quad_114_read_dummy_clocks : 5;
+    uint8_t quad_114_read_mode_clocks : 3;
+    uint8_t quad_114_read_cmd;
+
+    /* 4th DWORD */
+    uint32_t : 32;
+    /* 5th DWORD */
+    uint32_t : 32;
+    /* 6th DWORD */
+    uint32_t : 32;
+    /* 7th DWORD */
+    uint32_t : 32;
+
+    /* 8th and 9th DWORD */
+    struct {
+        uint8_t size;
+        uint8_t cmd;
+    } erase_info[4];
+
+    /* 10th DWORD */
+    uint32_t : 32; /* typical and maximum erase times */
+                   /* TODO could be nice for timeouts */
+
+    /* 11th DWORD */
+    /* typical and max chip erase and program times. page size. */
+    uint32_t typ_to_max_prog_time_multiplier : 4;
+    uint32_t page_size : 4;
+    uint32_t page_prog_time_typ : 6;
+    uint32_t byte_prog_time_first_typ : 5;
+    uint32_t byte_prog_time_addl_typ : 5;
+    uint32_t chip_erase_time_typ : 7;
+    uint32_t : 1; /* reserved */
+
+    /* 12th DWORD */
+    uint32_t : 32; /* suspend/resume info */
+
+    /* 13th DWORD */
+    uint32_t : 32; /* suspend/resume instructions */
+
+    /* 14th DWORD */
+    uint32_t : 2; /* reserved */
+    uint32_t busy_poll_methods : 6;
+    uint32_t  : 7; /* powerdown info */
+    uint32_t  : 8; /* powerdown info */
+    uint32_t  : 8; /* powerdown info */
+    uint32_t  : 1; /* powerdown info */
+
+    /* 15th DWORD */
+    uint32_t : 4; /* 4-4-4 mode disable */
+    uint32_t : 5; /* 4-4-4 mode enable */
+    uint32_t xip_mode_supported : 1;
+    uint32_t xip_mode_exit_method : 6;
+    uint32_t xip_mode_entry_method : 4;
+    uint32_t quad_enable_method : 3;
+    uint32_t hold_reset_disable : 1;
+    uint32_t : 8; /* reserved */
+
+    /* 16th DWORD */
+    uint32_t status_reg_1_info : 7;
+    uint32_t : 1; /* reserved */
+    uint32_t soft_reset_sequence : 6;
+    uint32_t four_byte_address_exit_method : 10;
+    uint32_t four_byte_address_enter_method : 8;
+
+} sfdp_parameter_table_t;
+
+typedef struct {
+    sfdp_header_t sfdp_header;
+    sfdp_parameter_header_t basic_parameter_header;
+    sfdp_parameter_table_t basic_parameter_table;
+} sfdp_info_t;
+
+#define SFDP_READ_CALLBACK_ATTR __attribute__((fptrgroup("sfdp_read_cb_fptr_grp")))
+
+typedef void (*sfdp_read_cb_t)(void *flash_ctx, uint8_t *data, uint32_t address, size_t len);
+
+size_t sfdp_flash_size_kbytes(sfdp_info_t *sfdp_info);
+size_t sfdp_flash_page_size_bytes(sfdp_info_t *sfdp_info);
+int sfdp_busy_poll_method(sfdp_info_t *sfdp_info,
+                          uint8_t *instruction,
+                          uint8_t *bit,
+                          uint8_t *ready_value);
+int sfdp_quad_enable_method(sfdp_info_t *sfdp_info,
+                            uint8_t *qe_reg,
+                            uint8_t *qe_bit,
+                            uint8_t *sr2_read_instruction,
+                            uint8_t *sr2_write_instruction);
+
+bool sfdp_discover(sfdp_info_t *sfdp_info,
+                   void *serial_flash_ctx,
+                   sfdp_read_cb_t sfdp_read);
+
+#endif /* SFDP_H_ */

--- a/modules/hil/lib_qspi_io/lib_qspi_io/api/sfdp.h
+++ b/modules/hil/lib_qspi_io/lib_qspi_io/api/sfdp.h
@@ -134,7 +134,7 @@ typedef struct {
 
 #define SFDP_READ_CALLBACK_ATTR __attribute__((fptrgroup("sfdp_read_cb_fptr_grp")))
 
-typedef void (*sfdp_read_cb_t)(void *flash_ctx, uint8_t *data, uint32_t address, size_t len);
+typedef void (*sfdp_read_cb_t)(void *flash_ctx, void *data, uint32_t address, size_t len);
 
 size_t sfdp_flash_size_kbytes(sfdp_info_t *sfdp_info);
 size_t sfdp_flash_page_size_bytes(sfdp_info_t *sfdp_info);

--- a/modules/hil/lib_qspi_io/lib_qspi_io/src/qspi_flash.c
+++ b/modules/hil/lib_qspi_io/lib_qspi_io/src/qspi_flash.c
@@ -275,6 +275,7 @@ void qspi_flash_poll_status_register(qspi_flash_ctx_t *ctx,
 	qspi_flash_poll_register(ctx, READ_STATUS_REG_COMMAND, mask, val);
 }
 
+__attribute__((always_inline))
 static void qspi_flash_fast_read_i(qspi_flash_ctx_t *ctx,
                                    uint32_t cmd,
                                    uint8_t *data,
@@ -315,19 +316,19 @@ void qspi_flash_fast_read(qspi_flash_ctx_t *ctx,
                           uint32_t address,
                           size_t len)
 {
-    qspi_flash_fast_read_i(ctx, QSPI_IO_BYTE_TO_MOSI(FAST_READ_COMMAND), data, address, len);
+    qspi_flash_ctx_t local_ctx = *ctx;
+    qspi_flash_fast_read_i(&local_ctx, QSPI_IO_BYTE_TO_MOSI(FAST_READ_COMMAND), data, address, len);
 }
 
 __attribute__ ((noinline))
-void qspi_flash_read_calc(qspi_flash_ctx_t *ctx,
-                          const int xip,
+static void qspi_flash_read_calc(const int xip,
 #if FOUR_BYTE_ADDRESS_SUPPORT
-                          const int four_byte_address,
+                                 const int four_byte_address,
 #endif
-                          uint32_t *address,
-                          size_t len,
-                          size_t *cycles,
-                          size_t *input_cycle)
+                                 uint32_t *address,
+                                 size_t len,
+                                 size_t *cycles,
+                                 size_t *input_cycle)
 {
 	/* The first input should occur on either the fourth
 	 * byte, or the last byte, whichever is first. */
@@ -404,7 +405,7 @@ inline void qspi_flash_read_i(qspi_flash_ctx_t *ctx,
 	size_t cycles;
 	size_t input_cycle;
 	
-	qspi_flash_read_calc(ctx, xip,
+	qspi_flash_read_calc(xip,
 #if FOUR_BYTE_ADDRESS_SUPPORT
                          four_byte_address,
 #endif
@@ -437,7 +438,8 @@ void qspi_flash_read(qspi_flash_ctx_t *ctx,
                      uint32_t address,
                      size_t len)
 {
-	qspi_flash_read_i(ctx, qspi_io_transfer_normal, 0,
+    qspi_flash_ctx_t local_ctx = *ctx;
+	qspi_flash_read_i(&local_ctx, qspi_io_transfer_normal, 0,
 #if FOUR_BYTE_ADDRESS_SUPPORT
 	                  0,
 #endif
@@ -449,7 +451,8 @@ void qspi_flash_read_nibble_swapped(qspi_flash_ctx_t *ctx,
                                     uint32_t address,
                                     size_t len)
 {
-	qspi_flash_read_i(ctx, qspi_io_transfer_nibble_swap, 0,
+    qspi_flash_ctx_t local_ctx = *ctx;
+	qspi_flash_read_i(&local_ctx, qspi_io_transfer_nibble_swap, 0,
 #if FOUR_BYTE_ADDRESS_SUPPORT
                       0,
 #endif
@@ -461,7 +464,8 @@ void qspi_flash_xip_read(qspi_flash_ctx_t *ctx,
                          uint32_t address,
                          size_t len)
 {
-	qspi_flash_read_i(ctx, qspi_io_transfer_normal, 1,
+    qspi_flash_ctx_t local_ctx = *ctx;
+	qspi_flash_read_i(&local_ctx, qspi_io_transfer_normal, 1,
 #if FOUR_BYTE_ADDRESS_SUPPORT
                       0,
 #endif
@@ -473,7 +477,8 @@ void qspi_flash_xip_read_nibble_swapped(qspi_flash_ctx_t *ctx,
                          uint32_t address,
                          size_t len)
 {
-	qspi_flash_read_i(ctx, qspi_io_transfer_nibble_swap, 1,
+    qspi_flash_ctx_t local_ctx = *ctx;
+	qspi_flash_read_i(&local_ctx, qspi_io_transfer_nibble_swap, 1,
 #if FOUR_BYTE_ADDRESS_SUPPORT
                       0,
 #endif
@@ -554,7 +559,8 @@ void qspi_flash_write(qspi_flash_ctx_t *ctx,
                       uint32_t address,
                       size_t len)
 {
-	qspi_flash_write_i(ctx, qspi_io_transfer_normal, data, address, len);
+    qspi_flash_ctx_t local_ctx = *ctx;
+	qspi_flash_write_i(&local_ctx, qspi_io_transfer_normal, data, address, len);
 }
 
 void qspi_flash_write_nibble_swapped(qspi_flash_ctx_t *ctx,
@@ -562,7 +568,8 @@ void qspi_flash_write_nibble_swapped(qspi_flash_ctx_t *ctx,
                       uint32_t address,
                       size_t len)
 {
-	qspi_flash_write_i(ctx, qspi_io_transfer_nibble_swap, data, address, len);
+    qspi_flash_ctx_t local_ctx = *ctx;
+	qspi_flash_write_i(&local_ctx, qspi_io_transfer_nibble_swap, data, address, len);
 }
 
 SFDP_READ_CALLBACK_ATTR
@@ -571,7 +578,8 @@ void qspi_flash_sfdp_read(qspi_flash_ctx_t *ctx,
                           uint32_t address,
                           size_t len)
 {
-    qspi_flash_fast_read_i(ctx, QSPI_IO_BYTE_TO_MOSI(SFDP_READ_INSTRUCTION), data, address, len);
+    qspi_flash_ctx_t local_ctx = *ctx;
+    qspi_flash_fast_read_i(&local_ctx, QSPI_IO_BYTE_TO_MOSI(SFDP_READ_INSTRUCTION), data, address, len);
 }
 
 void qspi_flash_deinit(qspi_flash_ctx_t *ctx)

--- a/modules/hil/lib_qspi_io/lib_qspi_io/src/qspi_io.c
+++ b/modules/hil/lib_qspi_io/lib_qspi_io/src/qspi_io.c
@@ -36,7 +36,6 @@ void qspi_io_init(const qspi_io_ctx_t *ctx,
 	 * NOTE: invert mode is not modeled correctly in xsim VCD trace.
 	 */
 	port_set_invert(ctx->cs_port);
-	//port_out(ctx->cs_port, 0);
 	/* Set chip select as the ready source for the clock */
 	clock_set_ready_src(ctx->clock_block, ctx->cs_port);
 

--- a/modules/hil/lib_qspi_io/lib_qspi_io/src/sfdp.c
+++ b/modules/hil/lib_qspi_io/lib_qspi_io/src/sfdp.c
@@ -1,0 +1,173 @@
+// Copyright 2021 XMOS LIMITED.
+// This Software is subject to the terms of the XMOS Public Licence: Version 1.
+
+#include "sfdp.h"
+#include "debug_print.h"
+
+size_t sfdp_flash_size_kbytes(sfdp_info_t *sfdp_info)
+{
+    size_t flash_size_kbytes;
+    if (sfdp_info->basic_parameter_table.memory_density_is_exponent) {
+        if (sfdp_info->basic_parameter_table.memory_density >=32 && sfdp_info->basic_parameter_table.memory_density <= 44) {
+            flash_size_kbytes = 1 << (sfdp_info->basic_parameter_table.memory_density - 13);
+        } else {
+            flash_size_kbytes = 0;
+        }
+    } else {
+        flash_size_kbytes = (1 + sfdp_info->basic_parameter_table.memory_density) >> 13;
+    }
+
+    return flash_size_kbytes;
+}
+
+size_t sfdp_flash_page_size_bytes(sfdp_info_t *sfdp_info)
+{
+    return 1 << sfdp_info->basic_parameter_table.page_size;
+}
+
+int sfdp_busy_poll_method(sfdp_info_t *sfdp_info,
+                          uint8_t *instruction,
+                          uint8_t *bit,
+                          uint8_t *ready_value)
+{
+    uint32_t method_set = sfdp_info->basic_parameter_table.busy_poll_methods;
+    if (method_set & SFDP_BUSY_POLL_ALT1_BM) {
+        *instruction = 0x70;
+        *bit = 7;
+        *ready_value = 1;
+    } else if (method_set & SFDP_BUSY_POLL_LEGACY_BM) {
+        *instruction = 0x05;
+        *bit = 0;
+        *ready_value = 0;
+    } else {
+        return -1;
+    }
+
+    return 0;
+}
+
+int sfdp_quad_enable_method(sfdp_info_t *sfdp_info,
+                            uint8_t *qe_reg,
+                            uint8_t *qe_bit,
+                            uint8_t *sr2_read_instruction,
+                            uint8_t *sr2_write_instruction)
+{
+    switch (sfdp_info->basic_parameter_table.quad_enable_method) {
+    case 0:
+        *qe_reg = 0;
+        *qe_bit = 0;
+        *sr2_read_instruction = 0;
+        *sr2_write_instruction = 0;
+        break;
+    case 1:
+        *qe_reg = 2;
+        *qe_bit = 1;
+        *sr2_read_instruction = 0;
+        *sr2_write_instruction = 0;
+        break;
+    case 2:
+        *qe_reg = 1;
+        *qe_bit = 6;
+        *sr2_read_instruction = 0;
+        *sr2_write_instruction = 0;
+        break;
+    case 3:
+        *qe_reg = 2;
+        *qe_bit = 7;
+        *sr2_read_instruction = 0x3F;
+        *sr2_write_instruction = 0x3E;
+        break;
+    case 4:
+        *qe_reg = 2;
+        *qe_bit = 1;
+        *sr2_read_instruction = 0;
+        *sr2_write_instruction = 0;
+        break;
+    case 5:
+        *qe_reg = 2;
+        *qe_bit = 1;
+        *sr2_read_instruction = 0x35;
+        *sr2_write_instruction = 0;
+        break;
+    case 6:
+        *qe_reg = 2;
+        *qe_bit = 1;
+        *sr2_read_instruction = 0x35;
+        *sr2_write_instruction = 0x31;
+        break;
+    default:
+        return -1;
+    }
+
+    return 0;
+}
+
+static void sfdp_erase_table_sort(sfdp_info_t *sfdp_info)
+{
+    sfdp_parameter_table_t *t = &sfdp_info->basic_parameter_table;
+    const int n = 4;
+    int i, j;
+    for (i = 0; i < n - 1; i++) {
+        for (j = 0; j < n - i - 1; j++) {
+            /* Treat size 0 as a maximum value to keep them at the end of the table */
+            if (t->erase_info[j].size == 0 || (t->erase_info[j + 1].size != 0 && t->erase_info[j].size > t->erase_info[j + 1].size)) {
+                uint8_t size = t->erase_info[j].size;
+                uint8_t cmd = t->erase_info[j].cmd;
+                t->erase_info[j].size = t->erase_info[j + 1].size;
+                t->erase_info[j].cmd = t->erase_info[j + 1].cmd;
+                t->erase_info[j + 1].size = size;
+                t->erase_info[j + 1].cmd = cmd;
+            }
+        }
+    }
+}
+
+bool sfdp_discover(sfdp_info_t *sfdp_info,
+                  void *serial_flash_ctx,
+                  SFDP_READ_CALLBACK_ATTR sfdp_read_cb_t sfdp_read)
+{
+    const uint32_t sfdp_signature = 0x50444653;
+    const uint8_t  req_major_revision = 1;
+    const uint8_t  req_min_minor_revision = 5;
+    size_t table_read_length;
+
+    sfdp_read(serial_flash_ctx, sfdp_info, 0x000000, sizeof(sfdp_header_t) + sizeof(sfdp_parameter_header_t));
+
+    table_read_length = sizeof(uint32_t) * sfdp_info->basic_parameter_header.length;
+
+    if (sfdp_info->sfdp_header.signature == sfdp_signature &&
+            sfdp_info->sfdp_header.major_revision == req_major_revision &&
+            sfdp_info->basic_parameter_header.major_revision == req_major_revision &&
+            sfdp_info->sfdp_header.minor_revision >= req_min_minor_revision &&
+            sfdp_info->basic_parameter_header.minor_revision >= req_min_minor_revision &&
+            table_read_length >= sizeof(sfdp_parameter_table_t)) {
+
+        debug_printf("Supported SFDP flash device found\n");
+
+    } else {
+        if (sfdp_info->sfdp_header.signature != sfdp_signature) {
+            debug_printf("No SFDP flash device found\n");
+        } else {
+            debug_printf("Unsupported SFDP flash device found\n");
+        }
+
+        return false;
+    }
+
+//    debug_printf("Parameter Table revision: %d.%d\n", sfdp_info->basic_parameter_header.major_revision, sfdp_info->basic_parameter_header.minor_revision);
+//    debug_printf("Parameter Table ID %02x%02x\n", sfdp_info->basic_parameter_header.id_msb, sfdp_info->basic_parameter_header.id_lsb);
+//    debug_printf("Parameter Table Address: %d\n", sfdp_info->basic_parameter_header.table_address);
+//    debug_printf("Parameter Table Length %d\n", sfdp_info->basic_parameter_header.length);
+
+
+    if (sizeof(sfdp_parameter_table_t) < table_read_length) {
+        table_read_length = sizeof(sfdp_parameter_table_t);
+    }
+
+    sfdp_read(serial_flash_ctx, &sfdp_info->basic_parameter_table, sfdp_info->basic_parameter_header.table_address, table_read_length);
+
+    /* Ensure that the erase table is sorted by size, with unused entries at the end. */
+    sfdp_erase_table_sort(sfdp_info);
+
+    return true;
+}

--- a/modules/hil/lib_qspi_io/lib_qspi_io/src/sfdp.c
+++ b/modules/hil/lib_qspi_io/lib_qspi_io/src/sfdp.c
@@ -1,6 +1,8 @@
 // Copyright 2021 XMOS LIMITED.
 // This Software is subject to the terms of the XMOS Public Licence: Version 1.
 
+#define DEBUG_UNIT SFDP
+
 #include "sfdp.h"
 #include "debug_print.h"
 
@@ -153,12 +155,6 @@ bool sfdp_discover(sfdp_info_t *sfdp_info,
 
         return false;
     }
-
-//    debug_printf("Parameter Table revision: %d.%d\n", sfdp_info->basic_parameter_header.major_revision, sfdp_info->basic_parameter_header.minor_revision);
-//    debug_printf("Parameter Table ID %02x%02x\n", sfdp_info->basic_parameter_header.id_msb, sfdp_info->basic_parameter_header.id_lsb);
-//    debug_printf("Parameter Table Address: %d\n", sfdp_info->basic_parameter_header.table_address);
-//    debug_printf("Parameter Table Length %d\n", sfdp_info->basic_parameter_header.length);
-
 
     if (sizeof(sfdp_parameter_table_t) < table_read_length) {
         table_read_length = sizeof(sfdp_parameter_table_t);

--- a/modules/rtos/drivers/qspi_flash/api/rtos_qspi_flash.h
+++ b/modules/rtos/drivers/qspi_flash/api/rtos_qspi_flash.h
@@ -271,11 +271,6 @@ void rtos_qspi_flash_start(
  * \param spi_read_sio_pad_delay         Number of core clock cycles to delay sampling the SIO pads during
  *                                       a SPI read transaction. This allows for more fine grained adjustment
  *                                       of sampling time. The value may be between 0 and 5.
- * \param quad_page_program_enable       If set to 1, then rtos_qspi_flash_write() will use all four SIO lines
- *                                       to send out the address and data. If set greater than 1, then qspi_flash_write()
- *                                       will send the address out on only SIO0 (MOSI) and the data out on all
- *                                       four SIO lines. Otherwise, if false then both the address and data will
- *                                       be sent out on only SIO0 (MOSI).
  * \param quad_page_program_cmd          The command that will be sent when rtos_qspi_flash_write() is called if
  *                                       quad_page_program_enable is true. This should be a value returned by
  *                                       the QSPI_IO_BYTE_TO_MOSI() macro.
@@ -304,8 +299,7 @@ void rtos_qspi_flash_init(
         uint32_t spi_read_sclk_sample_delay,
         qspi_io_sample_edge_t spi_read_sclk_sample_edge,
         uint32_t spi_read_sio_pad_delay,
-        int quad_page_program_enable,
-        uint32_t quad_page_program_cmd,
+        qspi_flash_page_program_cmd_t quad_page_program_cmd,
         uint32_t quad_enable_register_read_cmd,
         uint32_t quad_enable_register_write_cmd,
         uint32_t quad_enable_bitmask,

--- a/modules/rtos/drivers/qspi_flash/api/rtos_qspi_flash.h
+++ b/modules/rtos/drivers/qspi_flash/api/rtos_qspi_flash.h
@@ -45,13 +45,7 @@ struct rtos_qspi_flash_struct {
     void (*unlock)(rtos_qspi_flash_t *);
 
     qspi_flash_ctx_t ctx;
-
-    uint32_t quad_enable_register_read_cmd;
-    uint32_t quad_enable_register_write_cmd;
-    uint32_t quad_enable_bitmask;
-    size_t page_size;
     size_t flash_size;
-    uint32_t page_address_mask;
 
     unsigned op_task_priority;
     rtos_osal_thread_t op_task;
@@ -274,15 +268,6 @@ void rtos_qspi_flash_start(
  * \param quad_page_program_cmd          The command that will be sent when rtos_qspi_flash_write() is called if
  *                                       quad_page_program_enable is true. This should be a value returned by
  *                                       the QSPI_IO_BYTE_TO_MOSI() macro.
- * \param quad_enable_register_read_cmd  The command that will be sent when reading the register containing the
- *                                       "quad enabled" bit. This should be a value returned by the
- *                                       QSPI_IO_BYTE_TO_MOSI() macro.
- * \param quad_enable_register_write_cmd The command that will be sent when writing the register containing the
- *                                       "quad enabled" bit. This should be a value returned by the
- *                                       QSPI_IO_BYTE_TO_MOSI() macro.
- * \param quad_enable_bitmask            The bitmask to use when reading and writing the quad enabled bit.
- * \param page_size                      The size in bytes of each page in the connected QSPI flash chip.
- * \param page_count                     The number of pages in the connected QSPI flash chip.
  */
 void rtos_qspi_flash_init(
         rtos_qspi_flash_t *ctx,
@@ -299,12 +284,7 @@ void rtos_qspi_flash_init(
         uint32_t spi_read_sclk_sample_delay,
         qspi_io_sample_edge_t spi_read_sclk_sample_edge,
         uint32_t spi_read_sio_pad_delay,
-        qspi_flash_page_program_cmd_t quad_page_program_cmd,
-        uint32_t quad_enable_register_read_cmd,
-        uint32_t quad_enable_register_write_cmd,
-        uint32_t quad_enable_bitmask,
-        size_t page_size,
-        size_t page_count);
+        qspi_flash_page_program_cmd_t quad_page_program_cmd);
 
 /**@}*/
 

--- a/modules/rtos/drivers/qspi_flash/rtos_qspi_flash.c
+++ b/modules/rtos/drivers/qspi_flash/rtos_qspi_flash.c
@@ -52,13 +52,13 @@ static void read_op(
 
 static void while_busy(qspi_flash_ctx_t *ctx)
 {
-    uint8_t status;
+    bool busy;
 
     do {
         interrupt_mask_all();
-        qspi_flash_read_status_register(ctx, &status, sizeof(status));
+        busy = qspi_flash_write_in_progress(ctx);
         interrupt_unmask_all();
-    } while (status & QSPI_FLASH_STATUS_REG_WIP_BM);
+    } while (busy);
 }
 
 static void write_op(
@@ -77,7 +77,7 @@ static void write_op(
 
     while (bytes_left_to_write > 0) {
         /* compute the maximum number of bytes that can be written to the current page. */
-        size_t max_bytes_to_write = ctx->page_size - (address_to_write & ctx->page_address_mask);
+        size_t max_bytes_to_write = qspi_flash_ctx->page_size_bytes - (address_to_write & (qspi_flash_ctx->page_size_bytes - 1));
         size_t bytes_to_write = bytes_left_to_write <= max_bytes_to_write ? bytes_left_to_write : max_bytes_to_write;
 
         if (address_to_write >= ctx->flash_size) {
@@ -98,17 +98,6 @@ static void write_op(
         address_to_write += bytes_to_write;
     }
 }
-
-//#define SECTORS_TO_BYTES(s, ss) ((s) * (ss))
-//#define BYTES_TO_SECTORS(b, ss) (((b) + (ss) - 1) / (ss))
-//
-//#define SECTOR_TO_BYTE_ADDRESS(s, ss) SECTORS_TO_BYTES(s, ss)
-//#define BYTE_TO_SECTOR_ADDRESS(b, ss) ((b) / (ss))
-//
-//#define ERASE_SIZE_4K  4096
-//#define ERASE_SIZE_32K 32768
-//#define ERASE_SIZE_64K 65536
-//static const int erase_sizes[] = {ERASE_SIZE_4K, ERASE_SIZE_32K, ERASE_SIZE_64K};
 
 #define SECTORS_TO_BYTES(s, ss_log2) ((s) << (ss_log2))
 #define BYTES_TO_SECTORS(b, ss_log2) (((b) + (1 << ss_log2) - 1) >> (ss_log2))
@@ -140,22 +129,22 @@ static void erase_op(
         while_busy(qspi_flash_ctx);
     } else {
 
-        if (SECTOR_TO_BYTE_ADDRESS(BYTE_TO_SECTOR_ADDRESS(address_to_erase, QSPI_FLASH_ERASE_SIZE_LOG2(qspi_flash_ctx, 0)), QSPI_FLASH_ERASE_SIZE_LOG2(qspi_flash_ctx, 0)) != address_to_erase) {
+        if (SECTOR_TO_BYTE_ADDRESS(BYTE_TO_SECTOR_ADDRESS(address_to_erase, qspi_flash_erase_type_size_log2(qspi_flash_ctx, 0)), qspi_flash_erase_type_size_log2(qspi_flash_ctx, 0)) != address_to_erase) {
             /*
              * If the provided starting erase address does not begin on the smallest
              * sector boundary, then update the starting address and number of bytes
              * to erase so that it does.
              */
             unsigned sector_address;
-            sector_address = BYTE_TO_SECTOR_ADDRESS(address_to_erase, QSPI_FLASH_ERASE_SIZE_LOG2(qspi_flash_ctx, 0));
-            bytes_left_to_erase += address_to_erase - SECTOR_TO_BYTE_ADDRESS(sector_address, QSPI_FLASH_ERASE_SIZE_LOG2(qspi_flash_ctx, 0));
-            address_to_erase = SECTOR_TO_BYTE_ADDRESS(sector_address, QSPI_FLASH_ERASE_SIZE_LOG2(qspi_flash_ctx, 0));
+            sector_address = BYTE_TO_SECTOR_ADDRESS(address_to_erase, qspi_flash_erase_type_size_log2(qspi_flash_ctx, 0));
+            bytes_left_to_erase += address_to_erase - SECTOR_TO_BYTE_ADDRESS(sector_address, qspi_flash_erase_type_size_log2(qspi_flash_ctx, 0));
+            address_to_erase = SECTOR_TO_BYTE_ADDRESS(sector_address, qspi_flash_erase_type_size_log2(qspi_flash_ctx, 0));
             rtos_printf("adjusted starting erase address to %d\n", address_to_erase);
         }
 
         while (bytes_left_to_erase > 0) {
             int erase_length;
-            int erase_length_log2 = QSPI_FLASH_ERASE_SIZE_LOG2(qspi_flash_ctx, 0);
+            int erase_length_log2 = qspi_flash_erase_type_size_log2(qspi_flash_ctx, 0);
             qspi_flash_erase_length_t erase_cmd = qspi_flash_erase_1;
 
             if (address_to_erase >= ctx->flash_size) {
@@ -163,11 +152,10 @@ static void erase_op(
             }
 
             for (qspi_flash_erase_length_t i = qspi_flash_erase_4; i > qspi_flash_erase_1; i--) {
-                int sector_size_log2 = QSPI_FLASH_ERASE_SIZE_LOG2(qspi_flash_ctx, i);
-                int sector_size = QSPI_FLASH_ERASE_SIZE(qspi_flash_ctx, i);
-                if (SECTOR_TO_BYTE_ADDRESS(BYTE_TO_SECTOR_ADDRESS(address_to_erase, sector_size_log2), sector_size_log2) == address_to_erase) {
+                int sector_size_log2 = qspi_flash_erase_type_size_log2(qspi_flash_ctx, i);
+                if (sector_size_log2 != 0 && SECTOR_TO_BYTE_ADDRESS(BYTE_TO_SECTOR_ADDRESS(address_to_erase, sector_size_log2), sector_size_log2) == address_to_erase) {
                     /* The address we need to erase begins on a sector boundary */
-                    if (bytes_left_to_erase >= sector_size) {
+                    if (bytes_left_to_erase >= (1 << sector_size_log2)) {
                         /* And we still need to erase at least the size of this sector */
                         erase_length_log2 = sector_size_log2;
                         erase_cmd = i;
@@ -208,39 +196,9 @@ typedef struct {
     unsigned priority;
 } qspi_flash_op_req_t;
 
-static void enable_quad_mode(rtos_qspi_flash_t *ctx)
-{
-    uint8_t status;
-
-    interrupt_mask_all();
-    qspi_flash_read_register(&ctx->ctx, ctx->quad_enable_register_read_cmd, &status, sizeof(status));
-    interrupt_unmask_all();
-
-    if ((status & ctx->quad_enable_bitmask) == 0) {
-        status |= ctx->quad_enable_bitmask;
-        interrupt_mask_all();
-        qspi_flash_write_enable(&ctx->ctx);
-        interrupt_unmask_all();
-        interrupt_mask_all();
-        qspi_flash_write_register(&ctx->ctx, ctx->quad_enable_register_write_cmd, &status, 1);
-        interrupt_unmask_all();
-        while_busy(&ctx->ctx);
-
-        interrupt_mask_all();
-        qspi_flash_read_register(&ctx->ctx, ctx->quad_enable_register_read_cmd, &status, sizeof(status));
-        interrupt_unmask_all();
-        xassert((status & ctx->quad_enable_bitmask) != 0);
-    }
-}
-
 static void qspi_flash_op_thread(rtos_qspi_flash_t *ctx)
 {
     qspi_flash_op_req_t op;
-
-    /*
-     * Before entering the main loop, ensure the flash is in quad mode
-     */
-    enable_quad_mode(ctx);
 
     for (;;) {
         rtos_osal_queue_receive(&ctx->op_queue, &op, RTOS_OSAL_WAIT_FOREVER);
@@ -253,7 +211,9 @@ static void qspi_flash_op_thread(rtos_qspi_flash_t *ctx)
 
         switch (op.op) {
         case FLASH_OP_READ:
-            read_op(ctx, op.data, op.address, op.len);
+            if (op.len > 0) {
+                read_op(ctx, op.data, op.address, op.len);
+            }
             rtos_osal_semaphore_put(&ctx->data_ready);
             break;
         case FLASH_OP_WRITE:
@@ -389,12 +349,7 @@ void rtos_qspi_flash_init(
         uint32_t spi_read_sclk_sample_delay,
         qspi_io_sample_edge_t spi_read_sclk_sample_edge,
         uint32_t spi_read_sio_pad_delay,
-        qspi_flash_page_program_cmd_t quad_page_program_cmd,
-        uint32_t quad_enable_register_read_cmd,
-        uint32_t quad_enable_register_write_cmd,
-        uint32_t quad_enable_bitmask,
-        size_t page_size,
-        size_t page_count)
+        qspi_flash_page_program_cmd_t quad_page_program_cmd)
 {
     qspi_flash_ctx_t *qspi_flash_ctx = &ctx->ctx;
     qspi_io_ctx_t *qspi_io_ctx = &qspi_flash_ctx->qspi_io_ctx;
@@ -418,15 +373,11 @@ void rtos_qspi_flash_init(
 
     qspi_flash_init(qspi_flash_ctx);
 
-    ctx->quad_enable_register_read_cmd = quad_enable_register_read_cmd;
-    ctx->quad_enable_register_write_cmd = quad_enable_register_write_cmd;
-    ctx->quad_enable_bitmask = quad_enable_bitmask;
-    ctx->page_size = page_size;
-    ctx->flash_size = page_size * page_count;
-    ctx->page_address_mask = page_size - 1;
+    ctx->flash_size = qspi_flash_ctx->flash_size_kbytes * 1024;
+    xassert(ctx->flash_size > qspi_flash_ctx->flash_size_kbytes);
 
     /* Verify that the page size is a power of two */
-    xassert((page_size != 0) && ((page_size & ctx->page_address_mask) == 0));
+    xassert((qspi_flash_ctx->page_size_bytes != 0) && ((qspi_flash_ctx->page_size_bytes & (qspi_flash_ctx->page_size_bytes - 1)) == 0));
 
     ctx->rpc_config = NULL;
     ctx->read = qspi_flash_local_read;

--- a/modules/rtos/drivers/qspi_flash/rtos_qspi_flash.c
+++ b/modules/rtos/drivers/qspi_flash/rtos_qspi_flash.c
@@ -199,6 +199,10 @@ typedef struct {
 static void qspi_flash_op_thread(rtos_qspi_flash_t *ctx)
 {
     qspi_flash_op_req_t op;
+    bool quad_enabled;
+
+    quad_enabled = qspi_flash_quad_enable_write(&ctx->ctx, true);
+    xassert(quad_enabled && "QE bit could not be set\n");
 
     for (;;) {
         rtos_osal_queue_receive(&ctx->op_queue, &op, RTOS_OSAL_WAIT_FOREVER);


### PR DESCRIPTION
Update qspi flash lib and RTOS driver to use SFDP to determine qspi flash parameters. These parameters no longer need to be provided by the application, thus the API has changed.